### PR TITLE
Require clojure.pprint in core.clj

### DIFF
--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -5,6 +5,7 @@
             [loom.attr :as la]
             [ubergraph.protocols :as up]
             [dorothy.core :as d]
+            [clojure.pprint]
             ))
 
 (import-vars 


### PR DESCRIPTION
- This allows lein check to run successfully and
  ubergraph.core to be required in a non-aot compiled
  namespace.
