### PR TITLE
Update deps for compatibility with Clojure 1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/data.priority-map "0.0.5"]
-                 [aysylu/loom "0.5.0"]
+                 [org.clojure/data.priority-map "0.0.7"]
+                 [aysylu/loom "0.5.4"]
                  [dorothy "0.0.6"]
-                 [potemkin "0.3.13"]]
+                 [potemkin "0.4.1"]]
   :codox {:include [ubergraph.core ubergraph.alg]
           :src-dir-uri "http://github.com/Engelberg/ubergraph/tree/master/"
           :src-linenum-anchor-prefix "L"}


### PR DESCRIPTION
I had compile errors with Clojure 1.8.0-RC1, updating the dependencies fixed it. (They came from loom & potemkin, but I also updated priority-map while I was there).
