### PR TITLE
Fix for a bug in find-edges

### DIFF
--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -346,7 +346,7 @@ will `upgrade' the directed edge to undirected and merge attributes."
           attributes (dissoc attributes :src :dest)]
       (if (pos? (count attributes))
         (for [edge edges
-              :when (submap? attributes (get-in g [:attrs edge]))]
+              :when (submap? attributes (get-in g [:attrs (:id edge)]))]
           edge)
         edges))))
 


### PR DESCRIPTION
A call to find-edges with a query with more than just :src and :dest always returned an empty sequence. This commit fixes find-edges and adds a test to prove it.
