### PR TITLE
Fix bug in hash on Ubergraph, which causes bug in graph equality

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
                  [aysylu/loom "1.0.2"]
                  [dorothy "0.0.6"]
                  [potemkin "0.4.5"]]
-  :profiles {:master {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]]}}
   :codox {:output-path "doc"
           :namespaces [ubergraph.core ubergraph.alg]
           :source-uri "http://github.com/Engelberg/ubergraph/tree/master/{filepath}#L{line}"}

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [aysylu/loom "1.0.2"]
                  [dorothy "0.0.6"]
                  [potemkin "0.4.5"]]
+  :profiles {:master {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"]]}}
   :codox {:output-path "doc"
           :namespaces [ubergraph.core ubergraph.alg]
           :source-uri "http://github.com/Engelberg/ubergraph/tree/master/{filepath}#L{line}"}

--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -538,7 +538,7 @@ it is an edge."
   (add-directed-edges* g edges))
 
 (defn add-undirected-edges
-  "Adds directed edges, regardless of whether the underlying graph is directed or undirected"
+  "Adds undirected edges, regardless of whether the underlying graph is directed or undirected"
   [g & edges]
   (add-undirected-edges* g edges))
 
@@ -788,7 +788,7 @@ We're just checking the attributes here"
 
 (defn- node-set [^Ubergraph g]
   (let [^java.util.Map m (:node-map g)]
-    (.keySet m)))
+    (set (keys m))))
 
 (defn- equal-graphs? [^Ubergraph g1 ^Ubergraph g2]
   (or (.equals g1 g2)

--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -788,7 +788,7 @@ We're just checking the attributes here"
 
 (defn- node-set [^Ubergraph g]
   (let [^java.util.Map m (:node-map g)]
-    (set (keys m))))
+    (.keySet m)))
 
 (defn- equal-graphs? [^Ubergraph g1 ^Ubergraph g2]
   (or (.equals g1 g2)
@@ -811,7 +811,7 @@ We're just checking the attributes here"
         val @h]
     (if (= val -1)
       (let [ns (node-set g),
-            code (hash {:nodes ns,
+            code (hash {:nodes (hash-unordered-coll ns),
                         :node-attrs (node-attrs g),
                         :edges (edges-freqs g)})]
         (reset! h code)

--- a/test/ubergraph/core_test.clj
+++ b/test/ubergraph/core_test.clj
@@ -336,3 +336,20 @@
     ;; There should be no attributes for an edge that was removed,
     ;; then added back again without any attributes.
     (is (= (attrs g3 [1 2]) {}))))
+
+(deftest equality-still-true-after-caching-hash
+  (let [g1 (graph [(Integer. -1) (Integer. -2)])
+        g2 (graph [(Long. -1) (Long. -2)])]
+    ;; No cached hashes calculated yet, so ignored by this =
+    ;; comparison, which returns true
+    ;; because (= (Integer. -1) (Long. -1)) is true in Clojure.  Those
+    ;; values were selected because clojure.core/= is true between
+    ;; them, but Java .hashCode is different between them.
+    ;; clojure.core/hash is the same for both.
+    (is (= g1 g2))
+    ;; Force hashes to be calculated and cached.
+    (is (integer? (hash g1)))
+    (is (integer? (hash g2)))
+    ;; This will use calculated hashes during =, but should still be
+    ;; true.
+    (is (= g1 g2))))

--- a/test/ubergraph/core_test.clj
+++ b/test/ubergraph/core_test.clj
@@ -352,4 +352,4 @@
     (is (integer? (hash g2)))
     ;; This will use calculated hashes during =, but should still be
     ;; true.
-    (is (= g1 g2))))
+    (is (= g2 g1))))


### PR DESCRIPTION
The use of .keySet Java method in function node-set, which was used in hash calculation, causes clojure.core/hash of the mutable .keySet return value to be different than clojure.core/hash of the corresponding Clojure immutable set.

This is the same issue https://clojure.atlassian.net/browse/CLJ-1372 that comes up again in multiple Clojure data structure implementations whenever mutable Java set, maps, lists, etc. are hashed.