### PR TITLE
Add function for checking many invariants about data structures

### DIFF
--- a/src/ubergraph/invariants.clj
+++ b/src/ubergraph/invariants.clj
@@ -1,0 +1,263 @@
+(ns ubergraph.invariants
+  (:require [ubergraph.core :as uber]))
+
+
+;; TBD: Consider making custom implementations of a few functions from
+;; ubergraph.core namespace that are called in this namespace, to have
+;; an independently written implementation.
+
+;; uber/nodes
+;; uber/has-node?
+;; uber/edges
+
+;; These seem simple and straightforward enough to just reuse:
+
+;; uber/edge?
+;; uber/mirror-edge?
+;; uber/undirected-edge?
+;; uber/src
+;; uber/dest
+;; uber/ubergraph?
+
+
+(defn nodes-also-edges [g]
+  (filter uber/edge? (uber/nodes g)))
+
+
+(defn edge-id-set [g]
+  (set (map :id (uber/edges g))))
+
+
+(defn nodes-also-edge-uuids [g]
+  (filter (edge-id-set g) (uber/nodes g)))
+
+
+(defn nodes-logical-false [g]
+  (filter #(false? (boolean %)) (uber/nodes g)))
+
+
+(defn bad-attrs-keys [g]
+  (let [edge-id-set (edge-id-set g)]
+    (remove #(or (contains? edge-id-set %)
+                 (contains? (:node-map g) %))
+            (keys (:attrs g)))))
+
+
+(defn attrs-val-not-map [g]
+  (remove map? (vals (:attrs g))))
+
+
+(defn node-map-val-not-nodinfo-or-wrong-keys [g]
+  (remove (fn [x]
+            (and (instance? ubergraph.core.NodeInfo x)
+                 (= #{:in-edges :out-edges :in-degree :out-degree}
+                    (set (keys x)))))
+          (vals (:node-map g))))
+
+
+(defn node-info-wrong-degree [g]
+  (remove (fn [i]
+            (and
+             (= (:in-degree i) (reduce + (map count (vals (:in-edges i)))))
+             (= (:out-degree i) (reduce + (map count (vals (:out-edges i)))))))
+          (vals (:node-map g))))
+
+
+;; Every NodeInfo record has a map as the value associated with its
+;; keys :in-edges and :out-edges.  Every such map has keys that are
+;; all node values in the graph.
+
+(defn node-info-with-key-not-a-node [g]
+  (let [all-keys-are-nodes? (fn [m]
+                              (every? #(uber/has-node? g %) (keys m)))]
+    (remove (fn [i]
+              (and (all-keys-are-nodes? (:in-edges i))
+                   (all-keys-are-nodes? (:out-edges i))))
+            (vals (:node-map g)))))
+
+
+;; Following up on the comment of the previous function above, the
+;; associated values must be *non-empty* Clojure sets of edge objects.
+;; Maintaining the non-empty part of this invariant helps to enable
+;; faster implementations of the functions successors and
+;; predecessors.
+
+(defn node-info-with-val-empty-notset-or-contains-non-edge [g]
+  (let [good-edge-set? (fn [x]
+                         (and (set? x)
+                              (not (zero? (count x)))
+                              (every? uber/edge? x)))]
+    (remove (fn [i]
+              (and (every? good-edge-set? (vals (:in-edges i)))
+                   (every? good-edge-set? (vals (:out-edges i)))))
+            (vals (:node-map g)))))
+
+
+(defn duplicates [coll]
+  (into {} (for [[k v] (frequencies coll)
+                 :when (> v 1)]
+             [k v])))
+
+(comment 
+(= {} (duplicates [1 2 3 4]))
+(= {1 2, 3 3} (duplicates [1 2 3 4 1 3 5 3]))
+)
+
+
+(defn duplicate-edge-uuids [g]
+  (->> (uber/edges g)
+       (remove uber/mirror-edge?)
+       (map :id)
+       duplicates))
+
+
+;; Good undirected edges come in pairs, one with :mirror?  true, the
+;; other false, both with the same id, and with src and dest swapped.
+;; Return any non-good ones found.
+(defn undirected-edges-not-paired-correctly [g]
+  (let [uedges-by-id (->> (uber/edges g)
+                          (filter uber/undirected-edge?)
+                          (group-by :id))]
+    (remove (fn good-uedge-pair [[uuid edges]]
+              (and (= 2 (count edges))
+                   (= #{true false} (set (map uber/mirror-edge? edges)))
+                   (let [[e1 e2] edges]
+                     (and (= (uber/src e1) (uber/dest e2))
+                          (= (uber/dest e1) (uber/src e2))))))
+            uedges-by-id)))
+
+
+(defn edges-with-wrong-src-or-dest [g]
+  (concat
+   (for [[n1 node-info] (:node-map g)
+         [n2 out-edges] (:out-edges node-info)
+         out-edge out-edges
+         :when (or (not= n1 (uber/src out-edge))
+                   (not= n2 (uber/dest out-edge)))]
+     [n1 n2 out-edge])
+   (for [[n1 node-info] (:node-map g)
+         [n2 in-edges] (:in-edges node-info)
+         in-edge in-edges
+         :when (or (not= n2 (uber/src in-edge))
+                   (not= n1 (uber/dest in-edge)))]
+     [n1 n2 in-edge])))
+
+
+(defn check-invariants
+  "Checks whether the internal data structures of an ubergraph satisfy
+  invariants assumed by the implementation.  The implementation of
+  this function is one way to document these invariants, plus being an
+  executable way to check for bugs in the implementation.
+
+  Returns a map with the key :error, where the associated value is a
+  boolean indicating whether any errors were found.  Other keys can be
+  returned if there is an error, indicating details about any
+  invariant violations found."
+  [g]
+  (if-not (instance? ubergraph.core.Ubergraph g)
+    {:error true
+     :description "Not an ubergraph"}
+
+    (let [{:keys [node-map allow-parallel? undirected? attrs cached-hash]} g]
+      (cond
+        (not (map? node-map))
+        {:error true
+         :description "node-map value is not a map"}
+
+        (not (boolean? allow-parallel?))
+        {:error true
+         :description "allow-parallel? value is not a boolean"}
+
+        (not (boolean? undirected?))
+        {:error true
+         :description "undirected? value is not a boolean"}
+
+        (not (map? attrs))
+        {:error true
+         :description "attrs value is not a map"}
+
+        (not (instance? clojure.lang.Atom cached-hash))
+        {:error true
+         :description "cached-hash value is not an atom"}
+
+        (seq (nodes-also-edges g))
+        {:error true
+         :description "At least one node is also an edge"
+         :data (first (nodes-also-edges g))}
+
+        (seq (nodes-also-edge-uuids g))
+        {:error true
+         :description "At least one node is also an edge uuid value"
+         :data (first (nodes-also-edge-uuids g))}
+
+        (seq (bad-attrs-keys g))
+        {:error true
+         :description "At least one key in :attrs is neither a node nor an edge id"
+         :data (first (bad-attrs-keys g))}
+
+        (seq (attrs-val-not-map g))
+        {:error true
+         :description "At least one value in :attrs map is not a map"
+         :data (first (attrs-val-not-map g))}
+        
+        (seq (node-map-val-not-nodinfo-or-wrong-keys g))
+        {:error true
+         :description "At least one value in :node-map is not a NodeInfo record, or has the wrong keys"
+         :data (first (node-map-val-not-nodinfo-or-wrong-keys g))}
+        
+        (seq (node-info-wrong-degree g))
+        {:error true
+         :description "At least one value in :node-map has wrong value for :in-degree or :out-degree"
+         :data (first (node-info-wrong-degree g))}
+
+        (seq (node-info-with-key-not-a-node g))
+        {:error true
+         :description "At least one value in :node-map has a key that is not a node"
+         :data (first (node-info-with-key-not-a-node g))}
+
+        (seq (node-info-with-val-empty-notset-or-contains-non-edge g))
+        {:error true
+         :description "At least one value in :node-map has a value that is not a non-empty set of edges"
+         :data (first (node-info-with-val-empty-notset-or-contains-non-edge g))}
+
+        (seq (undirected-edges-not-paired-correctly g))
+        {:error true
+         :description "At least one undirected edge not paired correctly"
+         :data (first (undirected-edges-not-paired-correctly g))}
+
+        ;; When ignoring edges with :mirror? equal to true, all edge
+        ;; ids should be unique.
+        (seq (duplicate-edge-uuids g))
+        {:error true
+         :description "At least one duplicate edge UUID"
+         :data (first (duplicate-edge-uuids g))}
+
+        ;; TBD: if allow-parallel? is false, then there are no
+        ;; parallel edges in the graph.
+
+        (seq (edges-with-wrong-src-or-dest g))
+        {:error true
+         :description "At least one edge has the wrong src or dest node"
+         :data (first (edges-with-wrong-src-or-dest g))}
+
+        ;; Do NOT create a check that if a graph has undirected? true,
+        ;; then all of its edges are undirected, or conversely that if
+        ;; a graph has undireted? false then all of its edges are
+        ;; directed.  There are published functions add-directed-edges
+        ;; and add-undirected-edges that enable adding the "other
+        ;; kind" of edge to a graph that was created as directed, or
+        ;; undirected.
+
+        ;; Node values of false or nil lead to bugs in many functions
+        ;; of Loom and Ubergraph.  Multiple such functions use
+        ;; nil-punning, or create a set of nodes like 'some-set', and
+        ;; then do a membership check via evaluating an expression
+        ;; like (some-set possible-node), and assume the result is
+        ;; logical true if the node is in the set.
+        (seq (nodes-logical-false g))
+        {:error true
+         :description "At least one node is a logical false value"
+         :data (nodes-logical-false g)}
+        
+        :else
+        {:error false}))))

--- a/test/ubergraph/core_test.clj
+++ b/test/ubergraph/core_test.clj
@@ -1,9 +1,13 @@
 (ns ubergraph.core-test
   (:require [clojure.test :refer :all]
-            [ubergraph.core :refer :all]))
+            [ubergraph.core :refer :all]
+            [ubergraph.invariants :refer :all]))
 
 (defn vec-edges [g]
   (for [e (edges g) :when (not (mirror-edge? e))] [(src e) (dest e)]))
+
+(defn satisfies-invariants [g]
+  (is (= false (:error (check-invariants g)))))
 
 (deftest simple-graph-test
   (let [g1 (graph [1 2] [1 3] [2 3] 4)
@@ -11,6 +15,12 @@
         g3 (graph g1)
         g4 (graph g3 (digraph [5 6]) [7 8] 9)
         g5 (graph)]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3)
+      (satisfies-invariants g4)
+      (satisfies-invariants g5))
     (testing "Construction, nodes, edges"
       (are [expected got] (= expected got)
         #{1 2 3 4} (set (nodes g1))
@@ -54,6 +64,13 @@
         g4 (digraph g3 (graph [5 6]) [7 8] 9)
         g5 (digraph)
         g6 (transpose g1)]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3)
+      (satisfies-invariants g4)
+      (satisfies-invariants g5)
+      (satisfies-invariants g6))
     (testing "Construction, nodes, edges"
       (are [expected got] (= expected got)
         #{1 2 3 4} (set (nodes g1))
@@ -105,6 +122,12 @@
         g3 (graph g1)
         g4 (graph g3 (digraph [5 6 88]) [7 8] 9)
         g5 (graph)]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3)
+      (satisfies-invariants g4)
+      (satisfies-invariants g5))
     (testing "Construction, nodes, edges"
       (are [expected got] (= expected got)
         #{1 2 3 4} (set (nodes g1))
@@ -155,6 +178,13 @@
         g4 (digraph g3 (graph [5 6 88]) [7 8] 9)
         g5 (digraph)
         g6 (transpose g1)]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3)
+      (satisfies-invariants g4)
+      (satisfies-invariants g5)
+      (satisfies-invariants g6))
     (testing "Construction, nodes, edges"
       (are [expected got] (= expected got)
         #{1 2 3 4} (set (nodes g1))
@@ -213,6 +243,11 @@
         g2 (digraph [1 1])
         g3 (multigraph [1 1 {:color :red}] [1 1 {:color :blue}])
         g4 (multidigraph [1 1 {:color :red}] [1 1 {:color :blue}])]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3)
+      (satisfies-invariants g4))
     (testing "Undirected graph"
       (are [expected got] (= expected got)
         #{1} (set (successors g1 1))
@@ -247,6 +282,15 @@
         g3 (graph [1 2])
         ug4 (ubergraph false false [1 2])
         g4 (digraph [1 2])]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants ug1)
+      (satisfies-invariants g1)
+      (satisfies-invariants ug2)
+      (satisfies-invariants g2)
+      (satisfies-invariants ug3)
+      (satisfies-invariants g3)
+      (satisfies-invariants ug4)
+      (satisfies-invariants g4))
     (are [expected got] (= expected got)
          g1 ug1
          g2 ug2
@@ -289,6 +333,14 @@
         g5 (add-edges g4 [:a :y {:type "global"}])
         g6 (add-edges g5 [:x :y {:type "global" :position 5}])]
 
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g0)
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3)
+      (satisfies-invariants g4)
+      (satisfies-invariants g5)
+      (satisfies-invariants g6))
     (testing "finds edges by attribute"
       (is (= (make-edges :a :b)
              (do-find-edges g1 {:src :a :dest :b :type "local"})))
@@ -317,6 +369,10 @@
                          [1 2 {:label "edge12"}])
         g2 (remove-nodes g1 2)
         g3 (add-nodes g2 2)]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3))
     (is (= (attrs g1 2) {:label "n2"}))
     ;; There should be no attributes for a node that was removed, then
     ;; added back again without any attributes.
@@ -331,6 +387,10 @@
                          [1 2 {:label "edge12"}])
         g2 (remove-edges g1 [1 2])
         g3 (add-edges g2 [1 2])]
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2)
+      (satisfies-invariants g3))
     (is (= (attrs g1 [1 2]) {:label "edge12"}))
     (is (= (attrs g2 [1 2]) {}))
     ;; There should be no attributes for an edge that was removed,
@@ -352,4 +412,7 @@
     (is (integer? (hash g2)))
     ;; This will use calculated hashes during =, but should still be
     ;; true.
-    (is (= g2 g1))))
+    (is (= g2 g1))
+    (testing "Check internal invariants of data structures"
+      (satisfies-invariants g1)
+      (satisfies-invariants g2))))


### PR DESCRIPTION
This is a bit raw right now, perhaps, but I wanted to throw it over to you to see if you thought it would be of any interest.  It is a new namespace with a few functions that can check the ubergraph internal data structures to see whether they satisfy various conditions, that I think are intended to be always true, i.e. invariants.  It returns any violations it finds.

In this PR, the new code is not used at all in any "production path" code.  I did add a bunch of calls to the invariant checker in the tests, and they all still pass.