### PR TITLE
Throw exception on attempt to access attr of nonexistent edge object

### DIFF
--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -185,7 +185,7 @@
                   (assoc-in g [:attrs (resolve-node-or-edge g node-or-edge)]
                             (apply dissoc m attributes))))
   (remove-attrs [g n1 n2 attributes]
-                (remove-attrs g (get-edge n1 n2) attributes))
+                (remove-attrs g (get-edge g n1 n2) attributes))
 
   up/UndirectedGraph
   (other-direction [g edge]
@@ -473,7 +473,12 @@ an edge object."
 but this function also passes nodes through unchanged, and extracts the edge id if
 it is an edge."
   [g node-or-edge]
-  (cond (edge? node-or-edge) (:id node-or-edge)
+  (cond (edge? node-or-edge)
+        (if (contains? (get-in g [:node-map (src node-or-edge)
+                                  :out-edges (dest node-or-edge)])
+                       node-or-edge)
+          (:id node-or-edge)
+          (throw (IllegalArgumentException. (str "edge does not exist in graph g: " node-or-edge))))
         (has-node? g node-or-edge) node-or-edge
         :else
         (try (:id (edge-description->edge g node-or-edge))


### PR DESCRIPTION
This is one possible change that could be made to address issue #48.
It also adds many tests for attribute functions, both for existing and
non-existent nodes and edges, in directed and undirected graphs.  For
undirected graphs, it tries variations of accessing both edge
directions, to ensure that they both behave as "the same edge".

Also fix one arity bug.