### PR TITLE
fix a bug in the remove-attr for the case that the attribute-key is a

### DIFF
--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -174,7 +174,8 @@
   (add-attr [g n1 n2 k v] (add-attr g (get-edge g n1 n2) k v))
   (remove-attr [g node-or-edge k]
                (setval [(must :attrs (resolve-node-or-edge g node-or-edge))
-                        (compact k)]
+                        ALL
+                        #(= k (first %))]
                        NONE g))
   (remove-attr [g n1 n2 k] (remove-attr g (get-edge g n1 n2) k))
   (attr [g node-or-edge k]

--- a/src/ubergraph/core.clj
+++ b/src/ubergraph/core.clj
@@ -174,8 +174,7 @@
   (add-attr [g n1 n2 k v] (add-attr g (get-edge g n1 n2) k v))
   (remove-attr [g node-or-edge k]
                (setval [(must :attrs (resolve-node-or-edge g node-or-edge))
-                        ALL
-                        #(= k (first %))]
+                        (compact (keypath k))]
                        NONE g))
   (remove-attr [g n1 n2 k] (remove-attr g (get-edge g n1 n2) k))
   (attr [g node-or-edge k]

--- a/test/ubergraph/core_test.clj
+++ b/test/ubergraph/core_test.clj
@@ -444,4 +444,12 @@
     (testing "remove attr as vector"
       (is (= {:keyword 1
               {:k :v}  2}
-             (attrs (remove-attr g1 1 [:1 :2]) 1))))))
+             (attrs (remove-attr g1 1 [:1 :2]) 1))))
+
+    (testing "the attribute map of a node will be removed after the last attr is removed"
+      (is (= {}
+             (-> g1
+                 (remove-attr 1 :keyword)
+                 (remove-attr 1 [:1 :2])
+                 (remove-attr 1 {:k :v})
+                 :attrs))))))

--- a/test/ubergraph/core_test.clj
+++ b/test/ubergraph/core_test.clj
@@ -424,3 +424,24 @@
     (testing "Check internal invariants of data structures"
       (satisfies-invariants g1)
       (satisfies-invariants g2))))
+
+
+(deftest remove-attr-test
+  (let [g1 (multidigraph [1 {:keyword 1
+                             {:k :v}  2
+                             [:1 :2]  3}])]
+
+    (testing "remove attr as keyword"
+      (is (= {{:k :v} 2
+              [:1 :2] 3}
+             (attrs (remove-attr g1 1 :keyword) 1))))
+
+    (testing "remove attr as map"
+      (is (= {:keyword 1
+              [:1 :2]  3}
+             (attrs (remove-attr g1 1 {:k :v}) 1))))
+
+    (testing "remove attr as vector"
+      (is (= {:keyword 1
+              {:k :v}  2}
+             (attrs (remove-attr g1 1 [:1 :2]) 1))))))


### PR DESCRIPTION
In the current version (0.8.1), the remove-attr doesn't remove attribute from a  node if the attribute-key is a data-structure (i.e map, vector). Please see the test **remove-attr-test** for more details. This test is passed with the version 0.7.2, but not with the current version. 